### PR TITLE
Adding "decodeURI" so file names are not obfuscated

### DIFF
--- a/src/background/download.js
+++ b/src/background/download.js
@@ -54,7 +54,7 @@ function downloadItems (filteredItems, data) {
 
     browser.downloads.download({
       url: item.url,
-      filename: filename,
+      filename: decodeURI(filename),
       conflictAction: data.conflictAction,
       saveAs: false
     }).then(downloadId => {


### PR DESCRIPTION
"decodeURI" ensures that the download file and name does not contain "%20" (spaces) and other characters, which are stored otherwise.