### PR TITLE
Add new variables for url properties

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -294,6 +294,7 @@ app.factory('MediaItem', [
     function MediaItem (data) {
       this.source = data.source;
       this.url = data.url;
+      this.urlProps = new URL(this.url)
       this.mime = data.mime;
       this.tag = data.tag;
 
@@ -501,6 +502,19 @@ app.factory('NamingMask', [
       text: (mediaItem) => mediaItem.text || '',
       width: (mediaItem) => mediaItem.width || '',
       height: (mediaItem) => mediaItem.height || '',
+      // URL properties
+      hash: (mediaItem) => mediaItem.urlProps.hash || '',
+      host: (mediaItem) => mediaItem.urlProps.host || '',
+      hostname: (mediaItem) => mediaItem.urlProps.hostname || '',
+      href: (mediaItem) => mediaItem.urlProps.href || '',
+      origin: (mediaItem) => mediaItem.urlProps.origin || '',
+      password: (mediaItem) => mediaItem.urlProps.password || '',
+      pathname: (mediaItem) => mediaItem.urlProps.pathname || '',
+      port: (mediaItem) => mediaItem.urlProps.port || '',
+      protocol: (mediaItem) => mediaItem.urlProps.protocol || '',
+      search: (mediaItem) => mediaItem.urlProps.search || '',
+      searchParams: (mediaItem) => mediaItem.urlProps.searchParams || '',
+      username: (mediaItem) => mediaItem.urlProps.username || '',
       // Dynamic variables
       // An auto-incrementing number.
       inum: (mediaItem, namingMask) => {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -514,6 +514,7 @@ app.factory('NamingMask', [
       port: (mediaItem) => mediaItem.urlProps.port || '',
       protocol: (mediaItem) => mediaItem.urlProps.protocol || '',
       search: (mediaItem) => mediaItem.urlProps.search || '',
+      searchParams: (mediaItem) => mediaItem.urlProps.searchParams || {},
       username: (mediaItem) => mediaItem.urlProps.username || '',
       // Dynamic variables
       // An auto-incrementing number.
@@ -561,6 +562,11 @@ app.factory('NamingMask', [
       dateFormat: function (input, format = 'YYYY-MM-DDD') {
         let value = moment(input);
         return value.isValid() ? value.format(format) : input;
+      },
+      // Allow to get specific params of search
+      getParam: (input, param) =>  {
+        if (!(input instanceof URLSearchParams)) return 'BADARG';
+        return input.has(param) ? input.get(param) : ''
       }
     };
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -566,8 +566,9 @@ app.factory('NamingMask', [
       // Allow to get specific params of search
       getParam: (input, param) =>  {
         if (!(input instanceof URLSearchParams)) return 'BADARG';
-        return input.has(param) ? input.get(param) : ''
+        return input.has(param) ? input.get(param) : input
       }
+
     };
 
     /**

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -514,7 +514,6 @@ app.factory('NamingMask', [
       port: (mediaItem) => mediaItem.urlProps.port || '',
       protocol: (mediaItem) => mediaItem.urlProps.protocol || '',
       search: (mediaItem) => mediaItem.urlProps.search || '',
-      searchParams: (mediaItem) => mediaItem.urlProps.searchParams || '',
       username: (mediaItem) => mediaItem.urlProps.username || '',
       // Dynamic variables
       // An auto-incrementing number.

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -503,6 +503,7 @@ app.factory('NamingMask', [
       width: (mediaItem) => mediaItem.width || '',
       height: (mediaItem) => mediaItem.height || '',
       // URL properties
+      // https://developer.mozilla.org/en-US/docs/Web/API/URL#Properties
       hash: (mediaItem) => mediaItem.urlProps.hash || '',
       host: (mediaItem) => mediaItem.urlProps.host || '',
       hostname: (mediaItem) => mediaItem.urlProps.hostname || '',


### PR DESCRIPTION
Wiki should be updated accordingly.

Here is the new list of variables for the wiki entry:
```
${hash} | Contains a `#` followed by the identifier.
${host} | Hostname followed by port (if it was specified)
${hostname} | Contains the domain
${href} | Contains the whole URL
${origin} | Origin of the URL (structure same as `${href}`)
${password} | Contains the password (if it was specified)
${pathname} | Contains the path
${port} | Contains only the port number (if it was specified)
${protocol} | Contains protocol scheme including `:`
${search} | Contains everything after `?`
${searchParams} | This returns an object containing all search params (if there are any). To access the parameters, you need to use the `getParams` filter.
${username} | Contains the username (if it was specified)
```

And for filters:
```
getParams | param | Returns specific parameter for given `searchParams`
```