### PR TITLE
Add split filter

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -547,6 +547,11 @@ app.factory('NamingMask', [
       dateFormat: function (input, format = 'YYYY-MM-DDD') {
         let value = moment(input);
         return value.isValid() ? value.format(format) : input;
+      },
+      // Split input by separator and access nth element
+      split: (input, separator, index) => {
+        let elem = input.split(separator)[index]
+        return elem ? elem : input
       }
     };
 


### PR DESCRIPTION
The `replace` provides the same functionality but simple filters for specific purposes are better imo.

New table row inside WIki entry for filters:
```
split | separator, index | Splits input by `separator` and returns the nth element by `index`.
```