### PR TITLE
Fix "filer" > "filter" in messages.json

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -52,7 +52,7 @@
     "message": "Toggle regular expression mode"
   },
   "fastFilterClearTitle": {
-    "message": "Clear fast filer"
+    "message": "Clear fast filter"
   },
   "errorFastFilterNotRegex": {
     "message": "Not a valid regular expression."


### PR DESCRIPTION
A small, cosmetic typo fix.