### PR TITLE
Use `ng-cloak` for popup window until view is ready

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="popup.css">
   </head>
 
-  <body ng-controller="PopupCtrl as vm">
+  <body ng-controller="PopupCtrl as vm" ng-cloak>
     <form name="dsPopupForm">
       <!-- target controls -->
       <div class="form-row target-controls">

--- a/src/popup/popup.scss
+++ b/src/popup/popup.scss
@@ -224,3 +224,7 @@ form {
     margin-left: 5px;
   }
 }
+
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+    display: none !important;
+}


### PR DESCRIPTION
Based on the suggestion from @sokolow here: https://github.com/marklieberman/downloadstar/issues/49#issuecomment-406805255.

Wrapping the whole popup container with `ng-cloak` produced the best outcome for me. It takes around 1-2 seconds until the view comes up (for me at least) but I think instead of displaying a bogus window, this is the best approach.