### PR TITLE
Toggle alphabetical sorting of media items

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -129,6 +129,9 @@
   "onlyCheckedItemsTitle": {
     "message": "Show only checked items"
   },
+  "sortUrlsTitle": {
+    "message": "Sort items alphabetically by URL"
+  },
   "quickSearchPlaceholder": {
     "message": "Quick search"
   },

--- a/src/content/scrape.js
+++ b/src/content/scrape.js
@@ -165,8 +165,5 @@ var media = {
   })
 };
 
-// Sort the media by URL.
-media.items.sort((a, b) => a.url.localeCompare(b.url));
-
 // Return value for executeScript().
 media; // jshint ignore:line

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -368,6 +368,15 @@
               <i class="fa fa-clipboard-check"></i>
             </button>
           </div>
+          <!-- toggle sorting URLs -->
+          <div class="btn-group sort-toggle">
+            <button class="btn btn-outline-secondary btn-sm toggle-sort" type="button"
+                    ng-class="{ 'active': vm.controls.sortUrls }"
+                    ng-click="vm.toggleSortUrls()"
+                    i18n-title="'sortUrlsTitle'">
+              <i class="fa fa-sort-alpha-down"></i>
+            </button>
+          </div>
           <!-- quick search -->
           <div class="input-group input-group-sm quick-search">
             <div class="input-group-prepend">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -998,7 +998,7 @@ app.controller('PopupCtrl', [
     };
 
     /**
-     * Update listed MediaItems by sorting as needed and re-evaulating masks
+     * Update listed MediaItems by sorting if desired and re-evaluating masks
      */
     vm.updateMediaList = () => {
       if (vm.controls.sortUrls) {
@@ -1191,7 +1191,7 @@ app.controller('PopupCtrl', [
     };
 
     /**
-     * Toggle sorting MediaItems alphabetically by URL.
+     * Toggle sorting MediaItems alphabetically by URL or keeping DOM order.
      */
     vm.toggleSortUrls = function () {
       vm.controls.sortUrls = !vm.controls.sortUrls;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -799,6 +799,7 @@ app.controller('PopupCtrl', [
     // ----- Controller init -----
     vm.scraping = true;
     vm.media = [];
+    vm.unsortedMedia = [];
     vm.mediaFilters = MediaFilters;
     vm.lastClickedItem = null;
     vm.watchControls = false;
@@ -817,7 +818,8 @@ app.controller('PopupCtrl', [
       namingMask: '',
       conflictAction: 'skip',
       eraseHistory: false,
-      checkedOnly: false
+      checkedOnly: false,
+      sortUrls: false
     };
 
     // Use a bit of defineProperty magic to bind a simple hash of { filterType: enabled } to the enabled property of
@@ -945,8 +947,8 @@ app.controller('PopupCtrl', [
       // Put the scraped media on the controller if requested.
       return !assign ? promise : promise
         .then(media => {
-          vm.media = media;
-          vm.evaluateNamingMask(vm.getVisibleMediaItems());
+          vm.unsortedMedia = media;
+          vm.updateMediaList();
         })
         .finally(() => vm.scraping = false);
     };
@@ -988,11 +990,24 @@ app.controller('PopupCtrl', [
         // Put the scraped media on the controller if requested.
         return !assign ? promise : promise
           .then(media => {
-            vm.media = media;
-            vm.evaluateNamingMask(vm.getVisibleMediaItems());
+            vm.unsortedMedia = media;
+            vm.updateMediaList();
           })
           .finally(() => vm.scraping = false);
       });
+    };
+
+    /**
+     * Update listed MediaItems by sorting as needed and re-evaulating masks
+     */
+    vm.updateMediaList = () => {
+      if (vm.controls.sortUrls) {
+        vm.media = vm.unsortedMedia.slice().sort((a, b) => a.getUrl().localeCompare(b.getUrl()));
+      } else {
+        vm.media = vm.unsortedMedia;
+      }
+
+      vm.evaluateNamingMask(vm.getVisibleMediaItems());
     };
 
     /**
@@ -1173,6 +1188,15 @@ app.controller('PopupCtrl', [
     vm.toggleMediaSource = function (source) {
       vm.controls.sources[source] = !vm.controls.sources[source];
       vm.evaluateNamingMask(vm.getVisibleMediaItems());
+    };
+
+    /**
+     * Toggle sorting MediaItems alphabetically by URL.
+     */
+    vm.toggleSortUrls = function () {
+      vm.controls.sortUrls = !vm.controls.sortUrls;
+
+      vm.updateMediaList();
     };
 
     /**

--- a/src/popup/popup.scss
+++ b/src/popup/popup.scss
@@ -208,7 +208,7 @@ form {
   flex-flow: row nowrap;
   justify-content: flex-start;
 
-  .source-select {
+  .source-select, .sort-toggle {
     flex: 0 1 auto;
     margin-right: 5px;
   }


### PR DESCRIPTION
When using automatic numbering, there are cases where the original files are named unpredictably, either due to random generation or intentional obfuscation. With the current forced alphabetization of the media list, this can result in downloading and naming ordered items out of order.

I added the ability to toggle between the original, unordered list (preserving the order of elements in the scraped DOM) and the alphabetical URL sort that is currently mandatory. 