### PR TITLE
Add support for links in <area> tags

### DIFF
--- a/src/content/scrape.js
+++ b/src/content/scrape.js
@@ -37,16 +37,16 @@ function getNearbyText (element) {
 function getMediaAndLinks () {
   return Array.concat(
     // Collect the target of links.
-    Array.from(document.getElementsByTagName('a'), a => {
+    Array.from(getLinkElements(), link => {
       return {
         source: 'link',
-        url: tryDecodeURI(a.href),
+        url: tryDecodeURI(link.href),
         mime: null,
-        tag: a.tagName,
-        alt: a.alt || null,
-        title: a.title || null,
-        text: getNearbyText(a),
-        download: a.download || null
+        tag: link.tagName,
+        alt: link.alt || null,
+        title: link.title || null,
+        text: getNearbyText(link),
+        download: link.download || null
       };
     }),
     // Collect the source of images.
@@ -63,6 +63,13 @@ function getMediaAndLinks () {
         height: img.naturalHeight
       };
     })
+  );
+}
+
+function getLinkElements () {
+  return Array.concat(
+    Array.from(document.getElementsByTagName('a')),
+    Array.from(document.getElementsByTagName('area'))
   );
 }
 


### PR DESCRIPTION
[`<area>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area) is a tag that looks and works broadly similarly to `<a>` but is used to define regions in an image map rather than a normal link.  They're much less common, but I've recently run into a few of them in the wild which motivated this PR.