### PR TITLE
Use naming mask in download paths

### DIFF
--- a/src/background/download.js
+++ b/src/background/download.js
@@ -35,7 +35,7 @@ class QueueItem {
     this.finish = null;
 
     // Generate the target path for this item.
-    this.targetPath = [ data.options.downloadPath, this.getFilename() ]
+    this.targetPath = [ this.getFoldername(), this.getFilename() ]
       .filter(part => !!part)
       .join('/');
   }
@@ -59,6 +59,13 @@ class QueueItem {
    */
   getFilename () {
     return this.mediaItem.filename;
+  }
+
+  /**
+   * Get the folder name.
+   */
+  getFoldername () {
+    return this.mediaItem.foldername;
   }
 
   /**

--- a/src/common/_font-awesome-custom.scss
+++ b/src/common/_font-awesome-custom.scss
@@ -1,3 +1,3 @@
 $fa-font-path: '../common/fa-webfonts';
 @import "../../node_modules/@fortawesome/fontawesome-free/scss/fontawesome";
-@import "../../node_modules/@fortawesome/fontawesome-free/scss/fa-solid";
+@import "../../node_modules/@fortawesome/fontawesome-free/scss/solid";

--- a/src/content/scrape.js
+++ b/src/content/scrape.js
@@ -150,7 +150,8 @@ function getLinksFromText () {
  * Extract the title of the document.
  */
 function getTitle () {
-  return document.title;
+  // Get document title, and remove illegal characters for a Windows path
+  return document.title.replace(/[\\/:"*?<>|]/gi, ' ');
 }
 
 // Collect the media from this tab.

--- a/src/content/scrape.js
+++ b/src/content/scrape.js
@@ -146,12 +146,20 @@ function getLinksFromText () {
   return media;
 }
 
+/**
+ * Extract the title of the document.
+ */
+function getTitle () {
+  return document.title;
+}
+
 // Collect the media from this tab.
 var duplicates = new Set();
 var media = {
   meta: {
     frameUrl: String(window.location),
-    topFrame: (window.top === window)
+    topFrame: (window.top === window),
+    title: getTitle(),
   },
   items: Array.concat(getMediaAndLinks(), getAudioVideoMedia(), getLinksFromText()).filter(item => {
     // Eliminate invalid URLs.

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1246,6 +1246,9 @@ app.controller('PopupCtrl', [
      * Download the checked MediaItems.
      */
     vm.downloadMediaItems = () => {
+      // Re-evaluate naming masks before proceeding.
+      vm.evaluateNamingMask(vm.getVisibleMediaItems());
+
       // Save the interface controls before proceeding.
       saveControls().then(() => {
         browser.runtime.sendMessage({

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -314,6 +314,7 @@ app.factory('MediaItem', [
       this.matches = [];
       this.checked = false;
       this.maskName = null;
+      this.maskNameFolder = null;
     }
 
     /**
@@ -1056,6 +1057,7 @@ app.controller('PopupCtrl', [
 
       // Get an instance of NamingMask for this mask expression.
       let namingMask = new NamingMask(vm.controls.namingMask);
+      let namingMaskFolder = new NamingMask(vm.controls.downloadPath);
 
       // Expose the error if the mask expression is not valid.
       vm.namingMaskError = namingMask.error;
@@ -1063,6 +1065,7 @@ app.controller('PopupCtrl', [
       // Evaluate the mask expression on each MediaItem.
       mediaItems.forEach(mediaItem => {
         mediaItem.maskName = namingMask.evaluate(mediaItem);
+        mediaItem.maskNameFolder = namingMaskFolder.evaluate(mediaItem);
       });
     };
 
@@ -1239,7 +1242,8 @@ app.controller('PopupCtrl', [
             },
             mediaItems: vm.getCheckedMediaItems().map(mediaItem => ({
               url: mediaItem.getUrl(),
-              filename: mediaItem.maskName || mediaItem.getFilename()
+              filename: mediaItem.maskName || mediaItem.getFilename(),
+              foldername: mediaItem.maskNameFolder || 'DownloadStar',
             }))
           }
         });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -328,7 +328,7 @@ app.factory('MediaItem', [
      * Remove illegal characters for a Windows path (folder).
      */
     MediaItem.cleanPathFolder = function (input) {
-      return input.split(/[\\/]+/).map(segment => segment.replace(/[:"*?<>|]+/gi, ' ')).filter(segment => segment.trim()).join('/');
+      return input.split(/[\\/]+/).map(segment => segment.replace(/[:"*?<>|]+/gi, ' ').trim()).filter(segment => segment).join('/');
     };
 
     /**

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -318,10 +318,17 @@ app.factory('MediaItem', [
     }
 
     /**
-     * Remove illegal characters for a Windows path.
+     * Remove illegal characters for a Windows path (file).
      */
     MediaItem.cleanPath = function (input) {
-      return input.replace(/[\\/:"*?<>|]+/gi, '');
+      return input.replace(/[\\/:"*?<>|]+/gi, ' ');
+    };
+
+    /**
+     * Remove illegal characters for a Windows path (folder).
+     */
+    MediaItem.cleanPathFolder = function (input) {
+      return input.split(/[\\/]+/).map(segment => segment.replace(/[:"*?<>|]+/gi, ' ')).filter(segment => segment.trim()).join('/');
     };
 
     /**
@@ -779,6 +786,15 @@ app.factory('NamingMask', [
       }, ''));
     };
 
+    /**
+     * Evaluate the naming mask (folder) for a MediaItem.
+     */
+    NamingMask.prototype.evaluateFolder = function (mediaItem) {
+      return MediaItem.cleanPathFolder(this.tokens.reduce((output, token) => {
+        return output + (angular.isString(token) ? token : token(mediaItem));
+      }, ''));
+    };
+
     return NamingMask;
 
   }]);
@@ -1065,7 +1081,7 @@ app.controller('PopupCtrl', [
       // Evaluate the mask expression on each MediaItem.
       mediaItems.forEach(mediaItem => {
         mediaItem.maskName = namingMask.evaluate(mediaItem);
-        mediaItem.maskNameFolder = namingMaskFolder.evaluate(mediaItem);
+        mediaItem.maskNameFolder = namingMaskFolder.evaluateFolder(mediaItem);
       });
     };
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -330,7 +330,11 @@ app.factory('MediaItem', [
      * Remove illegal characters for a Windows path (folder).
      */
     MediaItem.cleanPathFolder = function (input) {
-      return input.split(/[\\/]+/).map(segment => segment.replace(/[:"*?<>|]+/gi, ' ').trim()).filter(segment => segment).join('/');
+      return input
+        .split(/[\\/]+/)
+        .map(part => part.replace(/[:"*?<>|]+/gi, ' ').trim())
+        .filter(part => !!part)
+        .join('/');
     };
 
     /**

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -296,6 +296,8 @@ app.factory('MediaItem', [
       this.url = new URL(data.url);
       this.tabUrl = data.tabUrl;
       this.frameUrl = data.frameUrl;
+      this.tabTitle = data.tabTitle;
+      this.frameTitle = data.frameTitle;
       this.mime = data.mime;
       this.tag = data.tag;
 
@@ -490,6 +492,10 @@ app.factory('NamingMask', [
       tabUrl: function (mediaItem) {
         return NamingMask.urlAsVariable(mediaItem.tabUrl, this.parameter);
       },
+      // title of the frame in which the MediaItem was found.
+      frameTitle: (mediaItem) => mediaItem.frameTitle,
+      // title of the tab in which the MediaItem was found.
+      tabTitle: (mediaItem) => mediaItem.tabTitle,
       // -- Dynamic or stateful variables.
       // An auto-incrementing number.
       inum: function (mediaItem) {
@@ -937,14 +943,18 @@ app.controller('PopupCtrl', [
           // Find the top frame to determinate the tab URL.
           let topFrame = frames.find(frame => frame.meta.topFrame);
           let tabUrl = new URL(topFrame.meta.frameUrl);
+          let tabTitle = topFrame.meta.title;
 
           // Construct MediaItem instances from the scraped items in each frame.
           let mediaItems = frames.reduce((media, frame) => {
             let frameUrl = new URL(frame.meta.frameUrl);
+            let frameTitle = frame.meta.title;
             for (let i = 0; i < frame.items.length; i++) {
               media.push(new MediaItem(angular.extend(frame.items[i], {
                 tabUrl,
-                frameUrl
+                frameUrl,
+                tabTitle,
+                frameTitle,
               })));
             }
             return media;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -323,7 +323,7 @@ app.factory('MediaItem', [
      * Remove illegal characters for a Windows path (file).
      */
     MediaItem.cleanPath = function (input) {
-      return input.replace(/[\\/:"*?<>|]+/gi, ' ');
+      return input.replace(/[\\/:"*?<>|]/gi, ' ');
     };
 
     /**
@@ -332,7 +332,7 @@ app.factory('MediaItem', [
     MediaItem.cleanPathFolder = function (input) {
       return input
         .split(/[\\/]+/)
-        .map(part => part.replace(/[:"*?<>|]+/gi, ' ').trim())
+        .map(part => part.replace(/[:"*?<>|]/gi, ' ').trim())
         .filter(part => !!part)
         .join('/');
     };


### PR DESCRIPTION
Partially addresses https://github.com/marklieberman/downloadstar/issues/52

Addresses https://github.com/marklieberman/downloadstar/issues/62

I've reused the logic for naming masks and applied it to folder paths, so that you can name a subfolder (and nested subfolders below that) based on variables.

Preview:
![downloadstar-folder-masks](https://user-images.githubusercontent.com/38416468/50541951-e1801b00-0beb-11e9-9b20-093e407bf1a0.gif)

Later, I added frameTitle and tabTitle as variables for the naming mask.

There was also an issue with one of the sass imports, when I `npm install`ed locally, the filename was `solid` rather than `fa-solid`.

I'm still learning, so open to all feedback.